### PR TITLE
Remove data_replicas variable

### DIFF
--- a/templates/kubebot-deployment.yaml
+++ b/templates/kubebot-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     component: kubebot
 spec:
-  replicas: {{ .data_replicas }}
+  replicas: 1
   template:
     metadata:
       labels:

--- a/values.toml
+++ b/values.toml
@@ -1,4 +1,3 @@
-data_replicas = 1
 kubebot_slack_token = ""
 kubebot_slack_channels_ids = ""
 kubebot_slack_admins_nicknames = ""


### PR DESCRIPTION
Probably one bot should be sufficient for most environments. I would remove the variable of replicas at least for now.
